### PR TITLE
Update train_crfnet.py

### DIFF
--- a/crfnet/train_crfnet.py
+++ b/crfnet/train_crfnet.py
@@ -128,7 +128,7 @@ def create_models(backbone_retinanet, num_classes, weights, multi_gpu=0,
         from keras.utils import multi_gpu_model
         
         with tf.device('/cpu:0'):
-            model = model_with_weights(backbone_retinanet(num_classes, num_anchors=num_anchors, modifier=modifier, inputs=inputs, distance=distance), weights=weights, skip_mismatch=True, config=copy.deepcopy(cfg), num_classes=num_classes)
+            model = model_with_weights(backbone_retinanet(num_classes, num_anchors=num_anchors, modifier=modifier, inputs=inputs, distance=distance,cfg = cfg), weights=weights, skip_mismatch=True, config=copy.deepcopy(cfg), num_classes=num_classes)
         
         training_model = multi_gpu_model(model, gpus=multi_gpu)
     else:


### PR DESCRIPTION
When I run "train_crfnet.py" on multi-gpus, it occured a problem:"some thing do not have attribute", after debug, I solved it by add "cfg = cfg" to the  line 131 function - backbone_retinante(**) of train_crfnet.py. The mainly reason are lacking of some key words.